### PR TITLE
feat: Allow custom paths for implementations

### DIFF
--- a/src/commands/nest/index.ts
+++ b/src/commands/nest/index.ts
@@ -14,7 +14,7 @@ import {
 } from "../../utils/shared-prints";
 import { COMMANDS } from "../../utils/commands";
 
-export const REPOSITORY = "frankmangone/nest-template-test";
+export const REPOSITORY = "SpaceUY/NestJS-Template";
 
 /**
  * Add a NestJS module to a project.
@@ -40,7 +40,14 @@ export const addNestModule = async (
     );
 
     const { path: implPath, name: implName } = implementation;
-    const pathInRepository = `${moduleConfig.path}/${implPath ?? implName}`;
+
+    let pathInRepository = "";
+
+    if (implPath === "") {
+      pathInRepository = `${moduleConfig.path}`;
+    } else {
+      pathInRepository = `${moduleConfig.path}/${implPath ?? implName}`;
+    }
 
     await cloneRepository(
       moduleConfig.name,

--- a/src/commands/nest/index.ts
+++ b/src/commands/nest/index.ts
@@ -39,7 +39,8 @@ export const addNestModule = async (
       implementations
     );
 
-    const pathInRepository = `${moduleConfig.path}/${implementation}`;
+    const { path: implPath, name: implName } = implementation;
+    const pathInRepository = `${moduleConfig.path}/${implPath ?? implName}`;
 
     await cloneRepository(
       moduleConfig.name,

--- a/src/commands/nest/utils/choose-module-implementation.ts
+++ b/src/commands/nest/utils/choose-module-implementation.ts
@@ -12,12 +12,12 @@ import { ModuleImplementationConfig } from "../../../utils/get-modules";
 export const chooseImplementation = async (
   moduleName: string,
   implementations: ModuleImplementationConfig[]
-): Promise<string> => {
+): Promise<ModuleImplementationConfig> => {
   if (implementations.length === 1) {
     console.log(
       `✓ Using default implementation: ${chalk.green(implementations[0].name)}`
     );
-    return implementations[0].name;
+    return implementations[0];
   }
 
   const questions = [
@@ -35,5 +35,5 @@ export const chooseImplementation = async (
   const implementation = answers.implementation;
 
   console.log(`✓ Using implementation: ${chalk.green(implementation)}`);
-  return implementation;
+  return implementations.find((impl) => impl.name === implementation)!;
 };

--- a/src/utils/get-modules.ts
+++ b/src/utils/get-modules.ts
@@ -20,6 +20,7 @@ interface PlanetaryConfig {
 export interface ModuleImplementationConfig {
   name: string;
   description: string;
+  path?: string;
 }
 
 export interface ModuleConfig {


### PR DESCRIPTION
Allows optionally specifying a custom path for implementations in specific modules.

This can be used for instance to target the module directory directly, without having any nesting.